### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,29 +6,29 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Timer	        KEYWORD1
+Timer	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-set             KEYWORD2
-start           KEYWORD2
-stop            KEYWORD2
-run             KEYWORD2
-pause           KEYWORD2
+set	KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
+run	KEYWORD2
+pause	KEYWORD2
 
-getMicros       KEYWORD2
-getMillis       KEYWORD2
-getSeconds      KEYWORD2
+getMicros	KEYWORD2
+getMillis	KEYWORD2
+getSeconds	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-MICROS	        LITERAL1
-MILLIS	        LITERAL1
-SECONDS	        LITERAL1
+MICROS	LITERAL1
+MILLIS	LITERAL1
+SECONDS	LITERAL1
 
-ONCE	        LITERAL1
-TWICE           LITERAL1
-NEVER	        LITERAL1
-FOREVER	        LITERAL1
+ONCE	LITERAL1
+TWICE	LITERAL1
+NEVER	LITERAL1
+FOREVER	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords